### PR TITLE
Allmaps::AnnotationsController

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: ['3.2', '3.3.0']
+        ruby_version: ['3.3.0']
         rails_version: [7.0.8]
 
     name: Test Blacklight / Ruby ${{ matrix.ruby_version }} / Rails ${{ matrix.rails_version }}
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: ['3.2', '3.3.0']
+        ruby_version: ['3.3.0']
         rails_version: [7.0.8]
 
     name: Test GeoBlacklight / Ruby ${{ matrix.ruby_version }} / Rails ${{ matrix.rails_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
+          bundler: 2.5.5
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -75,6 +76,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
+          bundler: 2.5.5
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
   linter:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.3
+        ruby-version: '3.3.0'
     - name: Install dependencies
       run: bundle install
     - name: Run linter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3.0'
+        ruby-version: 3.3
     - name: Install dependencies
       run: bundle install
     - name: Run linter
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: ['3.2', '3.3']
+        ruby_version: ['3.2', '3.3.0']
         rails_version: [7.0.8]
 
     name: Test Blacklight / Ruby ${{ matrix.ruby_version }} / Rails ${{ matrix.rails_version }}
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: ['3.2', '3.3']
+        ruby_version: ['3.2', '3.3.0']
         rails_version: [7.0.8]
 
     name: Test GeoBlacklight / Ruby ${{ matrix.ruby_version }} / Rails ${{ matrix.rails_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   linter:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: ['3.3.0']
+        ruby_version: ['3.2', '3.3']
         rails_version: [7.0.8]
 
     name: Test Blacklight / Ruby ${{ matrix.ruby_version }} / Rails ${{ matrix.rails_version }}
@@ -34,7 +34,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-          bundler: 2.5.5
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -66,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: ['3.3.0']
+        ruby_version: ['3.2', '3.3']
         rails_version: [7.0.8]
 
     name: Test GeoBlacklight / Ruby ${{ matrix.ruby_version }} / Rails ${{ matrix.rails_version }}
@@ -76,7 +75,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-          bundler: 2.5.5
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ruby-version
 *.gem
 Gemfile.lock
 /.bundle/

--- a/Gemfile
+++ b/Gemfile
@@ -6,20 +6,17 @@ gemspec
 
 group :test do
   gem "capybara", require: false
-  # gem "database_cleaner", require: false
   gem "engine_cart", require: false
   gem "factory_bot_rails", require: false
-  # gem "foreman", require: false
   gem "rails-controller-testing", require: false
   gem "rspec-rails", require: false
-  # gem "simplecov", require: false
   gem "standardrb", require: false
   gem "webdrivers", require: false
-  # gem "webmock", require: false
 end
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"
+
 # BEGIN ENGINE_CART BLOCK
 # engine_cart: 2.6.0
 # engine_cart stanza: 2.5.0
@@ -43,5 +40,11 @@ else
       gem "rails", ENV["RAILS_VERSION"]
     end
   end
+end
+
+if File.exist?("spec/test_app_templates/Gemfile.extra")
+  # rubocop:disable Security/Eval
+  eval File.read("spec/test_app_templates/Gemfile.extra"), nil, "spec/test_app_templates/Gemfile.extra"
+  # rubocop:enable Security/Eval
 end
 # END ENGINE_CART BLOCK

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :test do
   gem "capybara", require: false
   # gem "database_cleaner", require: false
   gem "engine_cart", require: false
-  # gem "factory_bot_rails", require: false
+  gem "factory_bot_rails", require: false
   # gem "foreman", require: false
   gem "rails-controller-testing", require: false
   gem "rspec-rails", require: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,16 @@
+require "rails"
 require "rake"
 require "bundler"
+
 Bundler::GemHelper.install_tasks
 
+require "bundler/setup"
 require "bundler/gem_tasks"
 
 require "rspec/core/rake_task"
 require "engine_cart/rake_task"
 require "solr_wrapper"
+require "solr_wrapper/rake_task"
 require "blacklight/allmaps/rake_task"
 
 task default: :ci

--- a/Rakefile
+++ b/Rakefile
@@ -18,12 +18,21 @@ task default: :ci
 desc "Run specs"
 RSpec::Core::RakeTask.new
 
-task ci: ["engine_cart:generate"] do
-  system "rake blacklight_allmaps:seed"
+task ci: ["blacklight_allmaps:generate"] do
+  within_test_app do
+    system "rake blacklight_allmaps:seed"
+  end
+
   Rake::Task["spec"].invoke
 end
 
 namespace :blacklight_allmaps do
+  
+  desc "Create the test rails app"
+  task generate: ["engine_cart:generate"] do
+    # Intentionally Empty Block
+  end
+
   desc "Put sample data into solr"
   task seed: ["engine_cart:generate"] do
     within_test_app do

--- a/Rakefile
+++ b/Rakefile
@@ -18,21 +18,12 @@ task default: :ci
 desc "Run specs"
 RSpec::Core::RakeTask.new
 
-task ci: ["blacklight_allmaps:generate"] do
-  within_test_app do
-    system "rake blacklight_allmaps:seed"
-  end
-
+task ci: ["engine_cart:generate"] do
+  system "rake blacklight_allmaps:seed"
   Rake::Task["spec"].invoke
 end
 
 namespace :blacklight_allmaps do
-  
-  desc "Create the test rails app"
-  task generate: ["engine_cart:generate"] do
-    # Intentionally Empty Block
-  end
-
   desc "Put sample data into solr"
   task seed: ["engine_cart:generate"] do
     within_test_app do

--- a/app/controllers/allmaps/annotations_controller.rb
+++ b/app/controllers/allmaps/annotations_controller.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
+
 module Allmaps
   class AnnotationsController < ApplicationController
     # JSON Only
     respond_to :json
 
     # Set @annotation before show and update
-    before_action :set_annotation, only: %i[ show update ]
+    before_action :set_annotation, only: %i[show update]
 
     # GET /annotations.json
     def index
@@ -34,13 +35,12 @@ module Allmaps
     end
 
     private
+
     # Find the annotation or throw a 404
     def set_annotation
-      begin
-        @annotation = Blacklight::Allmaps::Sidecar.where(solr_document_id: params[:id]).first!
-      rescue ActiveRecord::RecordNotFound
-        render json: { error: 'Record not found' }, status: :not_found
-      end
+      @annotation = Blacklight::Allmaps::Sidecar.where(solr_document_id: params[:id]).first!
+    rescue ActiveRecord::RecordNotFound
+      render json: {error: "Record not found"}, status: :not_found
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/allmaps/annotations_controller.rb
+++ b/app/controllers/allmaps/annotations_controller.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+module Allmaps
+  class AnnotationsController < ApplicationController
+    # JSON Only
+    respond_to :json
+
+    # Set @annotation before show and update
+    before_action :set_annotation, only: %i[ show update ]
+
+    # GET /annotations.json
+    def index
+      @annotations = Blacklight::Allmaps::Sidecar.order(:id).page params[:page]
+
+      respond_to do |format|
+        format.all { render json: @annotations }
+      end
+    end
+
+    # GET /annotations/1.json
+    def show
+      respond_to do |format|
+        format.all { render json: @annotation }
+      end
+    end
+
+    # PATCH/PUT /annotations/1.json
+    def update
+      # Background Job to store the Allmaps Annotation
+      Blacklight::Allmaps::StoreSidecarAnnotation.perform_later(@annotation.solr_document_id)
+
+      respond_to do |format|
+        format.json { render json: @annotation, status: :ok }
+      end
+    end
+
+    private
+    # Find the annotation or throw a 404
+    def set_annotation
+      begin
+        @annotation = Blacklight::Allmaps::Sidecar.where(solr_document_id: params[:id]).first!
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: 'Record not found' }, status: :not_found
+      end
+    end
+
+    # Only allow a list of trusted parameters through.
+    def annotation_params
+      params.require(:Blacklight::Allmaps::Sidecar).permit(:id, :solr_document_id)
+    end
+  end
+end

--- a/app/controllers/blacklight/allmaps/application_controller.rb
+++ b/app/controllers/blacklight/allmaps/application_controller.rb
@@ -1,6 +1,0 @@
-module Blacklight
-  module Allmaps
-    class ApplicationController < ActionController::Base
-    end
-  end
-end

--- a/app/views/allmaps/sidebar/_allmaps.html.erb
+++ b/app/views/allmaps/sidebar/_allmaps.html.erb
@@ -37,11 +37,23 @@
         const response = await fetch(annotationUrlByIIIFUri);
         if (!response.ok) {
           georefDiv.innerHTML = `<a href="https://editor.allmaps.org/#/collection?url=${manifestUrl}"><%= t('allmaps.georeference_link') %></a>`;
+
+          // If no annotation data is found, queue a background job to store the annotation data to the database
+          csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
+          fetch("/allmaps/annotations/" + "<%= @document.id %>", { 
+            method: "PUT", 
+            headers: {
+            "X-CSRF-Token": csrfToken,
+            "Content-Type": "application/json",
+            "Accept": "application/json"
+          }})
+            .then(response => response.json())
+            .then(data => console.log(data))
+            .catch(error => console.error(error));
+
         } else {
           const annotationUrl = response.url;
           georefDiv.innerHTML = `<a href="https://viewer.allmaps.org/?url=${annotationUrl}"><%= t('allmaps.georeferenced_link') %></a>`;
-          
-          // TODO: Ping Blacklight::Allmaps::AnnotationsController to save the annotation data
         }
       } catch (error) {
         console.error("Fetch error:", error);

--- a/app/views/annotations/_annotation.json.jbuilder
+++ b/app/views/annotations/_annotation.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! annotation, :id, :solr_document_id, :document_type, :manifest_id, :annotated, :allmaps_id, :iiif_manifest, :allmaps_annotation, :solr_version, :created_at, :updated_at
+

--- a/app/views/annotations/_annotation.json.jbuilder
+++ b/app/views/annotations/_annotation.json.jbuilder
@@ -1,2 +1,1 @@
 json.extract! annotation, :id, :solr_document_id, :document_type, :manifest_id, :annotated, :allmaps_id, :iiif_manifest, :allmaps_annotation, :solr_version, :created_at, :updated_at
-

--- a/app/views/annotations/_pagination.json.jbuilder
+++ b/app/views/annotations/_pagination.json.jbuilder
@@ -1,9 +1,9 @@
 json.pagination do
   current, total, per_page = collection.current_page, collection.total_pages, collection.limit_value
-  json.current  current
-  json.previous (current > 1 ? (current - 1) : nil)
-  json.next     (current == total ? nil : (current + 1))
+  json.current current
+  json.previous((current > 1) ? (current - 1) : nil)
+  json.next((current == total) ? nil : (current + 1))
   json.per_page per_page
-  json.pages    total
-  json.count    collection.total_count
+  json.pages total
+  json.count collection.total_count
 end

--- a/app/views/annotations/_pagination.json.jbuilder
+++ b/app/views/annotations/_pagination.json.jbuilder
@@ -1,0 +1,9 @@
+json.pagination do
+  current, total, per_page = collection.current_page, collection.total_pages, collection.limit_value
+  json.current  current
+  json.previous (current > 1 ? (current - 1) : nil)
+  json.next     (current == total ? nil : (current + 1))
+  json.per_page per_page
+  json.pages    total
+  json.count    collection.total_count
+end

--- a/app/views/annotations/index.json.jbuilder
+++ b/app/views/annotations/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.partial! "pagination", collection: @annotations
+json.data do
+  json.array! @annotations, partial: "annotations/annotation", as: :annotation
+end

--- a/app/views/annotations/show.json.jbuilder
+++ b/app/views/annotations/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "annotations/annotation", annotation: @annotation

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Blacklight::Allmaps::Engine.routes.draw do
   namespace :allmaps do
-    resources :annotations, only: [:index, :show, :update], defaults: { format: :json }
+    resources :annotations, only: [:index, :show, :update], defaults: {format: :json}
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,5 @@
 Blacklight::Allmaps::Engine.routes.draw do
+  namespace :allmaps do
+    resources :annotations, only: [:index, :show, :update], defaults: { format: :json }
+  end
 end

--- a/doc/development.md
+++ b/doc/development.md
@@ -62,3 +62,7 @@ following steps:
 1. run `npm install` to download dependencies
 1. run `npm run prepare` to build the bundle
 1. run `npm publish` to push the javascript package to https://npmjs.org/package/blacklight-allmaps
+
+## Running the Test suite
+
+LIGHT=geoblacklight bundle exec rake ci

--- a/lib/generators/blacklight/allmaps/config_generator.rb
+++ b/lib/generators/blacklight/allmaps/config_generator.rb
@@ -66,6 +66,10 @@ module Blacklight
         end
       end
 
+      def set_routes
+        inject_into_file "config/routes.rb", "mount Blacklight::Allmaps::Engine => '/'\n", before: /^end/
+      end
+
       def set_active_job_config
         inject_into_file "config/environments/development.rb", "  config.active_job.queue_adapter = :inline\n", after: "Rails.application.configure do\n"
       end

--- a/spec/controllers/annotations_controller_spec.rb
+++ b/spec/controllers/annotations_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Allmaps::AnnotationsController, type: :controller do
 
   # Setup for common prerequisites
   before(:each) do
-    request.headers['Accept'] = 'application/json'
+    request.headers["Accept"] = "application/json"
   end
 
   describe "GET #index" do
@@ -21,19 +21,19 @@ RSpec.describe Allmaps::AnnotationsController, type: :controller do
     context "when the annotation exists" do
       it "returns http success and the correct JSON structure" do
         annotation = FactoryBot.create(:annotation)
-        get :show, params: { id: annotation.solr_document_id }
+        get :show, params: {id: annotation.solr_document_id}
         expect(response).to have_http_status(:success)
         json_response = JSON.parse(response.body)
-        expect(json_response['id']).to eq(annotation.id)
+        expect(json_response["id"]).to eq(annotation.id)
       end
     end
 
     context "when the annotation does not exist" do
       it "returns a not found status" do
-        get :show, params: { id: 'nonexistent_id' }
+        get :show, params: {id: "nonexistent_id"}
         expect(response).to have_http_status(:not_found)
         json_response = JSON.parse(response.body)
-        expect(json_response['error']).to eq('Record not found')
+        expect(json_response["error"]).to eq("Record not found")
       end
     end
   end
@@ -44,7 +44,7 @@ RSpec.describe Allmaps::AnnotationsController, type: :controller do
         ActiveJob::Base.queue_adapter = :test
 
         annotation = FactoryBot.create(:annotation)
-        put :update, params: { id: annotation.solr_document_id }
+        put :update, params: {id: annotation.solr_document_id}
         expect(response).to have_http_status(:ok)
         expect { Blacklight::Allmaps::StoreSidecarAnnotation.perform_later }.to have_enqueued_job
       end
@@ -52,10 +52,10 @@ RSpec.describe Allmaps::AnnotationsController, type: :controller do
 
     context "when the annotation does not exist" do
       it "returns a not found status" do
-        put :update, params: { id: 'nonexistent_id' }
+        put :update, params: {id: "nonexistent_id"}
         expect(response).to have_http_status(:not_found)
         json_response = JSON.parse(response.body)
-        expect(json_response['error']).to eq('Record not found')
+        expect(json_response["error"]).to eq("Record not found")
       end
     end
   end

--- a/spec/controllers/annotations_controller_spec.rb
+++ b/spec/controllers/annotations_controller_spec.rb
@@ -1,0 +1,62 @@
+require "spec_helper"
+
+RSpec.describe Allmaps::AnnotationsController, type: :controller do
+  routes { Blacklight::Allmaps::Engine.routes }
+
+  # Setup for common prerequisites
+  before(:each) do
+    request.headers['Accept'] = 'application/json'
+  end
+
+  describe "GET #index" do
+    it "returns http success and the correct JSON structure" do
+      get :index
+      expect(response).to have_http_status(:success)
+      json_response = JSON.parse(response.body)
+      expect(json_response).to be_a(Array)
+    end
+  end
+
+  describe "GET #show" do
+    context "when the annotation exists" do
+      it "returns http success and the correct JSON structure" do
+        annotation = FactoryBot.create(:annotation)
+        get :show, params: { id: annotation.solr_document_id }
+        expect(response).to have_http_status(:success)
+        json_response = JSON.parse(response.body)
+        expect(json_response['id']).to eq(annotation.id)
+      end
+    end
+
+    context "when the annotation does not exist" do
+      it "returns a not found status" do
+        get :show, params: { id: 'nonexistent_id' }
+        expect(response).to have_http_status(:not_found)
+        json_response = JSON.parse(response.body)
+        expect(json_response['error']).to eq('Record not found')
+      end
+    end
+  end
+
+  describe "PATCH/PUT #update" do
+    context "when the annotation exists" do
+      it "updates the annotation and returns http success" do
+        ActiveJob::Base.queue_adapter = :test
+
+        annotation = FactoryBot.create(:annotation)
+        put :update, params: { id: annotation.solr_document_id }
+        expect(response).to have_http_status(:ok)
+        expect { Blacklight::Allmaps::StoreSidecarAnnotation.perform_later }.to have_enqueued_job
+      end
+    end
+
+    context "when the annotation does not exist" do
+      it "returns a not found status" do
+        put :update, params: { id: 'nonexistent_id' }
+        expect(response).to have_http_status(:not_found)
+        json_response = JSON.parse(response.body)
+        expect(json_response['error']).to eq('Record not found')
+      end
+    end
+  end
+end

--- a/spec/factories/annotations.rb
+++ b/spec/factories/annotations.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :annotation, class: 'Blacklight::Allmaps::Sidecar' do
+    solr_document_id { "abc_#{rand(1000)}" }
+    document_type { 'SolrDocument' }
+    manifest_id { "http://example.com/manifest/#{rand(1000)}" }
+    annotated { true }
+    allmaps_id { Digest::SHA1.hexdigest(manifest_id)[0..15]}
+    iiif_manifest { "http://example.com/iiif/#{rand(1000)}" }
+    allmaps_annotation { "http://example.com/annotation/#{rand(1000)}" }
+    solr_version { 1 }
+  end
+end

--- a/spec/factories/annotations.rb
+++ b/spec/factories/annotations.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
-  factory :annotation, class: 'Blacklight::Allmaps::Sidecar' do
+  factory :annotation, class: "Blacklight::Allmaps::Sidecar" do
     solr_document_id { "abc_#{rand(1000)}" }
-    document_type { 'SolrDocument' }
+    document_type { "SolrDocument" }
     manifest_id { "http://example.com/manifest/#{rand(1000)}" }
     annotated { true }
-    allmaps_id { Digest::SHA1.hexdigest(manifest_id)[0..15]}
+    allmaps_id { Digest::SHA1.hexdigest(manifest_id)[0..15] }
     iiif_manifest { "http://example.com/iiif/#{rand(1000)}" }
     allmaps_annotation { "http://example.com/annotation/#{rand(1000)}" }
     solr_version { 1 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require "rails-controller-testing" if Rails::VERSION::MAJOR >= 5
 require "rspec/rails"
 require "capybara/rspec"
 require "webdrivers"
+require "factory_bot_rails"
 
 Capybara.register_driver :headless_chrome do |app|
   Capybara::Selenium::Driver.load_selenium
@@ -42,6 +43,6 @@ RSpec.configure do |config|
   #     end
   config.infer_spec_type_from_file_location!
   config.fixture_path = "#{Blacklight::Allmaps.root}/spec/fixtures"
-
+  config.include FactoryBot::Syntax::Methods
   config.include Devise::Test::ControllerHelpers, type: :controller
 end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -18,6 +18,7 @@ class TestAppGenerator < Rails::Generators::Base
 
     Bundler.with_unbundled_env do
       run "bundle install"
+      run "bundle lock --add-platform ruby"
     end
   end
 


### PR DESCRIPTION
Basic JSON controller to list harvested Allmaps annotations data. On catalog#show, if the Allmaps sidecar JS doesn't find an annotated match, we queue a background job to try harvesting that manifest again.

```
Routes for Blacklight::Allmaps::Engine:
allmaps_annotations GET   /allmaps/annotations(.:format)     allmaps/annotations#index {:format=>:json}
 allmaps_annotation GET   /allmaps/annotations/:id(.:format) allmaps/annotations#show {:format=>:json}
                    PATCH /allmaps/annotations/:id(.:format) allmaps/annotations#update {:format=>:json}
                    PUT   /allmaps/annotations/:id(.:format) allmaps/annotations#update {:format=>:json}
```