### PR TITLE
IIIF Manifest: top-level identifier could be "@id" or "id"

### DIFF
--- a/app/jobs/blacklight/allmaps/store_sidecar_annotation.rb
+++ b/app/jobs/blacklight/allmaps/store_sidecar_annotation.rb
@@ -15,7 +15,10 @@ module Blacklight
           if response.code == 200
             # @TODO: validate the response body is a valid IIIF Manifest
             sidecar.iiif_manifest = response.body
-            sidecar.manifest_id = JSON.parse(sidecar.iiif_manifest)["@id"]
+
+            # Store the Manifest ID
+            # - Could be either "@id" or "id"
+            sidecar.manifest_id = JSON.parse(sidecar.iiif_manifest)["@id"] || JSON.parse(sidecar.iiif_manifest)["id"]
           end
 
           # Store the Allmaps Annotation

--- a/spec/fixtures/solr_documents/geoblacklight/gbl_btaa_northwestern_georeferenced.json
+++ b/spec/fixtures/solr_documents/geoblacklight/gbl_btaa_northwestern_georeferenced.json
@@ -1,0 +1,57 @@
+{
+  "id": "6cd985a1-1b1f-4d72-be9c-d64e5b3cdb30",
+  "gbl_mdVersion_s": "Aardvark",
+  "dct_title_s": "Western Africa",
+  "dct_description_sm": [
+    "1 map : hand colored; 41 x 51 cm",
+    "by Sidney Hall ; Scale approximately 1:8,000,000(W 15⁰--E 15⁰/N 20⁰--S 5⁰) ; Prime meridian: Greenwich ; Covers Western Africa and part of Central Africa ; Relief shown by hachures ; Shows routes of exploration in West Africa ; In margin: XLI, 41 ; London : Longman, Rees, Orme, Brown & Green"
+  ],
+  "dct_creator_sm": [
+    "Longman, Rees, Orme, Brown, and Green",
+    "Hall, Sidney"
+  ],
+  "dct_publisher_sm": [
+    "Longman, Rees, Orme, Brown & Green"
+  ],
+  "schema_provider_s": "Northwestern University",
+  "gbl_resourceClass_sm": [
+    "Maps"
+  ],
+  "dct_subject_sm": [
+    "Discovery and exploration"
+  ],
+  "dct_temporal_sm": [
+    "1829"
+  ],
+  "gbl_indexYear_im": [
+    1829
+  ],
+  "gbl_dateRange_drsim": [
+    "[1829 TO 1829]"
+  ],
+  "dct_spatial_sm": [
+    "Africa",
+    "West Africa",
+    "Central Africa"
+  ],
+  "locn_geometry": "POLYGON((-15.0 20.0, 15.0 20.0, 15.0 -5.0, -15.0 -5.0, -15.0 20.0))",
+  "dcat_bbox": "ENVELOPE(-15.0,15.0,20.0,-5.0)",
+  "dcat_centroid": "7.5,0.0",
+  "pcdm_memberOf_sm": [
+    "64bd8c4c-8e60-4956-b43d-bdc3f93db488"
+  ],
+  "dct_isPartOf_sm": [
+    "15d-01"
+  ],
+  "dct_rights_sm": [
+    "No Copyright - United States",
+    "The images on this web site, from maps in the collection of the Melville J. Herskovits Library of African Studies and housed in the Government & Geographic Information Collection of Northwestern University Libraries are in the public domain in the United States, and as such, not subject to copyright restriction. The Libraries request users cite both the URL and Northwestern University Libraries if they wish to reproduce images from the repository. For access to higher resolution images please contact repository@northwestern.edu"
+  ],
+  "dct_accessRights_s": "Public",
+  "dct_references_s": "{\"http://schema.org/url\":\"https://dc.library.northwestern.edu/items/6cd985a1-1b1f-4d72-be9c-d64e5b3cdb30\",\"http://iiif.io/api/presentation#manifest\":\"https://api.dc.library.northwestern.edu/api/v2/works/6cd985a1-1b1f-4d72-be9c-d64e5b3cdb30?as=iiif\"}",
+  "dct_identifier_sm": [
+    "9943163944202441",
+    "ark:/81985/n2dn4042x"
+  ],
+  "gbl_mdModified_dt": "2024-02-29T19:28:55Z"
+}


### PR DESCRIPTION
Add a fixture with a top-level IIIF Manifest "id" attribute. Harvest "@id" and "id" manifest ids.

Fixes #39