### PR TITLE
AnnotationsController -  fetch action

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,27 @@ LIGHT=blacklight bundle exec rails generate blacklight:allmaps:install
 LIGHT=geoblacklight bundle exec rails generate blacklight:allmaps:install
 ```
 
+## CatalogController Configuration
+
+Configure options for local use are set into the `catalog_controller.rb` file. 
+
+### Blacklight
+
+```ruby
+    # Blacklight::Allmaps Viewer
+    config.show.partials.insert(1, :blacklight_allmaps)
+    config.default_solr_unique_key = "id"
+    config.default_georeferenced_field = "bl_georeferenced_bsi"
+    config.default_iiif_manifest_field = "iiif_manifest_url_ssi"
+```
+
+### GeoBlacklight
+```ruby
+    # Blacklight::Allmaps Viewer
+    config.default_solr_unique_key = "id"
+    config.default_georeferenced_field = "gbl_georeferenced_b"
+```
+
 ## Rake Tasks
 
 ### Seed Fixtures
@@ -68,11 +89,8 @@ We expose the georeferenced items in the Blacklight user interface via a Georefe
 ![Screen shot](doc/georeferenced_facet.png)
 
 ```bash
-# For Blacklight...
-LIGHT=blacklight rake blacklight_allmaps:index:bl_georeferenced_facet
-
-# For GeoBlacklight...
-LIGHT=geoblacklight rake blacklight_allmaps:index:gbl_georeferenced_facet
+# For Blacklight or GeoBlacklight
+rake blacklight_allmaps:index:georeferenced_facet
 ```
 
 ## ActiveRecord Objects — Blacklight::Allmaps::Sidecar 
@@ -81,7 +99,8 @@ Blacklight::Allmaps adopts the SolrDocumentSidecar "sidecar" pattern from [Spotl
 
 We use this `document.sidecar_allmaps` object to hold the results of the Allmaps Annotation harvest task.
 
-The Blacklight::Allmaps::Sidecar object contains:
+The `Blacklight::Allmaps::Sidecar` object contains:
+
 | Field | Value |
 | --- | --- |
 | id | primary key |
@@ -113,6 +132,21 @@ document.sidecar_allmaps =>
  solr_version: 1794605692067250176,
  created_at: Tue, 26 Mar 2024 15:47:49.422826000 UTC +00:00,
  updated_at: Tue, 26 Mar 2024 16:39:42.427682000 UTC +00:00>
+```
+
+## Allmaps::AnnotationsController
+
+We've added an annotations controller to the application to expose the `Blacklight::Allmaps::Sidecar` data we've harvested. This controller returns only JSON. 
+
+The `#fetch` method will query Allmaps in real time for updated annotation data, should a nightly harvest (rake) be insufficient for Solr indexing or local development needs.
+
+```
+Routes for Blacklight::Allmaps::Engine:
+fetch_allmaps_annotation GET   /allmaps/annotations/:id/fetch(.:format) allmaps/annotations#fetch {:format=>:json}
+     allmaps_annotations GET   /allmaps/annotations(.:format)           allmaps/annotations#index {:format=>:json}
+      allmaps_annotation GET   /allmaps/annotations/:id(.:format)       allmaps/annotations#show {:format=>:json}
+                         PATCH /allmaps/annotations/:id(.:format)       allmaps/annotations#update {:format=>:json}
+                         PUT   /allmaps/annotations/:id(.:format)       allmaps/annotations#update {:format=>:json}
 ```
 
 ## Contributing

--- a/app/controllers/allmaps/annotations_controller.rb
+++ b/app/controllers/allmaps/annotations_controller.rb
@@ -8,7 +8,7 @@ module Allmaps
     # Set @annotation before show and update
     before_action :set_annotation, only: %i[show update]
 
-    # GET /annotations.json
+    # GET /allmaps/annotations.json
     def index
       @annotations = Blacklight::Allmaps::Sidecar.order(:id).page params[:page]
 
@@ -17,14 +17,14 @@ module Allmaps
       end
     end
 
-    # GET /annotations/1.json
+    # GET /allmaps/annotations/1.json
     def show
       respond_to do |format|
         format.all { render json: @annotation }
       end
     end
 
-    # PATCH/PUT /annotations/1.json
+    # PATCH/PUT /allmaps/annotations/1.json
     def update
       # Background Job to store the Allmaps Annotation
       Blacklight::Allmaps::StoreSidecarAnnotation.perform_later(@annotation.solr_document_id)
@@ -32,6 +32,20 @@ module Allmaps
       respond_to do |format|
         format.json { render json: @annotation, status: :ok }
       end
+    end
+
+    # GET /annotations/fetch/1.json
+    def fetch
+      # Background Job to store the Allmaps Annotation — Perform Now
+
+      Blacklight::Allmaps::StoreSidecarAnnotation.perform_now(params[:id])
+      set_annotation
+
+      respond_to do |format|
+        format.all { render json: @annotation }
+      end
+    rescue Blacklight::Exceptions::RecordNotFound
+      render json: {error: "Record not found"}, status: :not_found
     end
 
     private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Blacklight::Allmaps::Engine.routes.draw do
   namespace :allmaps do
-    resources :annotations, only: [:index, :show, :update], defaults: {format: :json}
+    resources :annotations, only: [:index, :show, :update], defaults: {format: :json} do
+      member do
+        get "fetch"
+      end
+    end
   end
 end

--- a/spec/controllers/annotations_controller_spec.rb
+++ b/spec/controllers/annotations_controller_spec.rb
@@ -59,4 +59,16 @@ RSpec.describe Allmaps::AnnotationsController, type: :controller do
       end
     end
   end
+
+  describe "GET #fetch" do
+    it "fetches the annotation and returns http success" do
+      ActiveJob::Base.queue_adapter = :test
+
+      annotation = FactoryBot.create(:annotation)
+
+      # Only check for route existence in this test
+      # StoreSidecarAnnotation.perform_now will error b/c the annotation does not exist
+      get :fetch, params: {id: annotation.id}
+    end
+  end
 end

--- a/spec/helpers/blacklight/allmaps/application_helper_spec.rb
+++ b/spec/helpers/blacklight/allmaps/application_helper_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "blacklight/allmaps/application_helper"
 
 # @TODO: GeoBlacklight dependent
 describe Blacklight::Allmaps::ApplicationHelper, type: :helper do


### PR DESCRIPTION
This PR adds a `#fetch` method to the AnnotationsController. For any doc.id, this method will live query Allmaps for the latest annotation data, should the nightly harvest (via rake) prove insufficient.

Also, updates the README to include information on the latest enhancements for a v0.3.0 release coming soon.